### PR TITLE
Base plus

### DIFF
--- a/action.php
+++ b/action.php
@@ -5,11 +5,20 @@
 */
 // must be run within Dokuwiki
 if(!defined('DOKU_INC')) die();
+ if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
 class action_plugin_nodisp extends DokuWiki_Action_Plugin {
     public function register(Doku_Event_Handler $controller) {   
        $controller->register_hook('TPL_CONTENT_DISPLAY', 'BEFORE', $this, 'handle_wiki_content'); 	    
     }
 
+  function __construct() {
+      
+      if(file_exists(DOKU_PLUGIN . 'nodisp/syntax.php')) {
+               msg("Please remove syntax.php from lib/plugins/nodisp or remove the plugin and reinstall");
+      }
+     
+  }
+  
   function handle_wiki_content(Doku_Event $event, $param) {    
     global $ACT;
     $act = act_clean($ACT);

--- a/action.php
+++ b/action.php
@@ -41,7 +41,7 @@ class action_plugin_nodisp extends DokuWiki_Action_Plugin {
       }
         
      $event->data = preg_replace_callback(    
-         '|<div class = "nodisp_(\d+)"><!-- nodisp -->(.*?)<!-- nodisp -->' . "\n" . '<\/div>|ms',
+         '|<div class = "nodisp_(\d+)"><!-- nodisp -->(.*?)<!-- nodisp -->.*?<\/div>|ms',
         function($matches) {     
            global $ID;
            $acl = auth_quickaclcheck($ID);

--- a/action.php
+++ b/action.php
@@ -25,6 +25,18 @@ class action_plugin_nodisp extends DokuWiki_Action_Plugin {
                return $matches[0];
             },$event->data
          ) ;
+         
+         $event->data = preg_replace_callback( 
+            '|\{nodisp (\d+)\}.*?\{\/nodisp\}|ms',
+            function($matches) {     
+               global $ID;
+               $acl = auth_quickaclcheck($ID);
+               if($acl < $matches[1]) {
+                   return "";
+               }          
+               return $matches[0];
+            },$event->data
+         ) ;
           return;
       }
         

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   nodisp
 author Myron Turner
 email  turnermm02@shaw.ca
-date 2021-06-05
+date 2021-07-23
 name   nodisp
 desc   Hide text from brwosoer display or remove from output to browser depending on acl
 url    https://www.dokuwiki.org/plugin:nodisp

--- a/syntax/basic.php
+++ b/syntax/basic.php
@@ -12,23 +12,14 @@
      */
     class syntax_plugin_nodisp_basic extends DokuWiki_Syntax_Plugin {
     
- //   protected  $p_type = 'normal';
-
-    
         function getType(){ return 'container'; }
-    
         function getAllowedTypes() { return array('formatting', 'substition', 'disabled', 'protected', 'container', 'paragraphs' ); }   
         function getSort(){ return 168; }
 
-     
-     
-     
         /**
          * Handle the match
          */
         function handle($match, $state, $pos, Doku_Handler $handler){
-
-
 /*
  none   0
  read   1

--- a/syntax/basic.php
+++ b/syntax/basic.php
@@ -10,28 +10,17 @@
      * All DokuWiki plugins to extend the parser/rendering mechanism
      * need to inherit from this class
      */
-    class syntax_plugin_nodisp extends DokuWiki_Syntax_Plugin {
-     
-        /**
-         * return some info
-         */
-        function getInfo(){
-            return array(
-                'author' => 'Myron Turner',
-                'email'  => 'turnermm02 AT shaw DOT ca',
-                'date'   => '2016-01-16',
-                'name'   => 'nodisp Plugin',
-                'desc'   => 'hides display of enclosed text',
-                'url'    => 'http://www.mturner.org',
-            );
-        }
-     
+    class syntax_plugin_nodisp_basic extends DokuWiki_Syntax_Plugin {
+    
+ //   protected  $p_type = 'normal';
+
+    
         function getType(){ return 'container'; }
-        function getPType(){ return 'stack'; }
+    
         function getAllowedTypes() { return array('formatting', 'substition', 'disabled', 'protected', 'container', 'paragraphs' ); }   
         function getSort(){ return 168; }
-        function connectTo($mode) { $this->Lexer->addEntryPattern('<nodisp.*?>(?=.*?</nodisp>)',$mode,'plugin_nodisp'); }
-        function postConnect() { $this->Lexer->addExitPattern('</nodisp>','plugin_nodisp'); }
+
+     
      
      
         /**
@@ -50,14 +39,14 @@
 */
             switch ($state) {
               case DOKU_LEXER_ENTER : 
-              if(preg_match("/(\d+)/",$match,$matches) ){
-                  $level = "nodisp_" . $matches[1];
-                   return array($state,"<div class = \"$level\"><!-- nodisp -->\n");
-              }
-               return array($state, "<div style='display:none'><!-- nodisp -->\n");
+                  if(preg_match("/(\d+)/",$match,$matches) ){
+                      $level = "nodisp_" . $matches[1];
+                       return array($state,"<div class = \"$level\"><!-- nodisp -->\n");
+                  }
+                   return array($state, "<div style='display:none'><!-- nodisp -->\n");     
      
               case DOKU_LEXER_UNMATCHED :  return array($state, $match);
-              case DOKU_LEXER_EXIT :       return array($state, '');
+              case DOKU_LEXER_EXIT :   return array($state, '');
             }
        
             return array();

--- a/syntax/basic.php
+++ b/syntax/basic.php
@@ -59,7 +59,7 @@
                   case DOKU_LEXER_UNMATCHED :  $renderer->doc .= $renderer->_xmlEntities($match); break;
                   case DOKU_LEXER_EXIT : 
                        if($INFO['isadmin'] || $INFO['ismanager'] ) break;   
-                    $renderer->doc .= "<!-- nodisp -->\n</div>";
+                    $renderer->doc .= "<!-- nodisp --></div>";
                     break;
                 }
                 return true;

--- a/syntax/normal.php
+++ b/syntax/normal.php
@@ -1,0 +1,12 @@
+<?php
+
+require_once(dirname(__FILE__).'/basic.php');
+
+
+class syntax_plugin_nodisp_normal extends syntax_plugin_nodisp_basic  {
+   function getPType(){ return  'normal'; }
+    function connectTo($mode) { $this->Lexer->addEntryPattern('{nodisp.*?}(?=.*?{/nodisp})',$mode,'plugin_nodisp_normal'); }
+    function postConnect() { $this->Lexer->addExitPattern('{/nodisp}','plugin_nodisp_normal'); }
+
+}
+

--- a/syntax/stack.php
+++ b/syntax/stack.php
@@ -1,18 +1,9 @@
 <?php
-/**
- * Alternate span syntax component for the wrap plugin
- *
- * Defines  <wrap> ... </wrap> syntax
- *
- * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     Anika Henke <anika@selfthinker.org>
- */
 
 require_once(dirname(__FILE__).'/basic.php');
 
 
 class syntax_plugin_nodisp_stack extends syntax_plugin_nodisp_basic {
-  //protected  $p_type = 'stack';
    function getPType(){ return  'stack'; }
     function connectTo($mode) { $this->Lexer->addEntryPattern('<nodisp.*?>(?=.*?</nodisp>)',$mode,'plugin_nodisp_stack'); }
     function postConnect() { $this->Lexer->addExitPattern('</nodisp>','plugin_nodisp_stack'); }

--- a/syntax/stack.php
+++ b/syntax/stack.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Alternate span syntax component for the wrap plugin
+ *
+ * Defines  <wrap> ... </wrap> syntax
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Anika Henke <anika@selfthinker.org>
+ */
+
+require_once(dirname(__FILE__).'/basic.php');
+
+
+class syntax_plugin_nodisp_stack extends syntax_plugin_nodisp_basic {
+  //protected  $p_type = 'stack';
+   function getPType(){ return  'stack'; }
+    function connectTo($mode) { $this->Lexer->addEntryPattern('<nodisp.*?>(?=.*?</nodisp>)',$mode,'plugin_nodisp_stack'); }
+    function postConnect() { $this->Lexer->addExitPattern('</nodisp>','plugin_nodisp_stack'); }
+
+}
+

--- a/version
+++ b/version
@@ -1,2 +1,2 @@
-master_21-Jun_05-15_25
+base_plus_21-Jul_23-11_09
 


### PR DESCRIPTION
The <nodisp. . . > syntax sets off blocks of text. This branch adds the {nodisp. . .} syntax, which treats the enclosed text as a single line unless an extra newline or the DokuWiki newline markup is inserted. See https://github.com/turnermm/nodisp/issues/3