### PR TITLE
Corrected typo

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -3,5 +3,5 @@ author Myron Turner
 email  turnermm02@shaw.ca
 date 2022-09-14
 name   nodisp
-desc   Hide text from brwosoer display or remove from output to browser depending on acl
+desc   Hide text from browser's display or remove from output to browser depending on acl
 url    https://www.dokuwiki.org/plugin:nodisp


### PR DESCRIPTION
Corrected typo ("brwosoer" instead of "browser") from text shown on Dokuwiki Extension Manager when inspecting this lovely (really amazing!) plugin.