### PR TITLE
Update basic.php: fix deprecation "require(syntax.php)"

### DIFF
--- a/syntax/basic.php
+++ b/syntax/basic.php
@@ -3,9 +3,6 @@
     // must be run within DokuWiki
     if(!defined('DOKU_INC')) die();
      
-    if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-    require_once(DOKU_PLUGIN.'syntax.php');
-     
     /**
      * All DokuWiki plugins to extend the parser/rendering mechanism
      * need to inherit from this class


### PR DESCRIPTION
Fix deprecation warning for `require(syntax.php)` in syntax/basic.php